### PR TITLE
Minor updates to toplevel package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,11 +20,12 @@
     "@angular/platform-browser": "^4.0.0",
     "@angular/platform-browser-dynamic": "^4.0.0",
     "@angular/router": "^4.0.0",
-    "angularfire2": "^2.0.0-beta.8",
+    "angularfire2": "2.0.0-beta.8",
     "core-js": "^2.4.1",
     "firebase": "^3.7.3",
     "rxjs": "^5.1.0",
-    "zone.js": "^0.8.4"
+    "zone.js": "^0.8.4",
+    "nodemailer": "^4.0"
   },
   "devDependencies": {
     "@angular/cli": "1.0.0",


### PR DESCRIPTION
The nodemailer dependency was missing in packages.json.

There are also errors when a current latest version of angularfire2 is used.
